### PR TITLE
[14.0][IMP] repos.yaml: website_slides PT_BR change to use branch

### DIFF
--- a/odoo/custom/src/repos.yaml
+++ b/odoo/custom/src/repos.yaml
@@ -13,8 +13,9 @@
   target: ocb $ODOO_VERSION
   merges:
     - ocb $ODOO_VERSION
-    - escodoo refs/pull/1/head # WEBSITE_SLIDES REMOVE PT_BR TRANSLATIONS
+    - escodoo 14.0-hack-website_slides # WEBSITE_SLIDES REMOVE PT_BR TRANSLATIONS
     # - escodoo refs/pull/2/head # ACCOUNT SET PASS IN MODEL (PROCESS MIGRATION SCRIPT)
+
 field-service:
   defaults:
     depth: $DEPTH_MERGE


### PR DESCRIPTION
cc @marcelsavegnago 


PR referente para utilizar a branch ao invés de passar por exemplo /refs/head/1, como o OCB muda constante e as vezes com algum rebase a PR pode acontecer de fechar então acredito que seria melhor utilizarmos no repos.yaml o nome da branch em si.